### PR TITLE
Rebuild plotly-resampler 0.8.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,10 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - poetry-core >=1.1.0a6
+    - poetry-core 1.4.0
   run:
     - python
     - {{ pin_compatible('numpy') }} 
-    - numpy >=1.24  # [py>=311]
     - dash >=2.2.0,<3.0.0
     - jupyter-dash >=0.4.2
     - orjson >=3.8.0,<4.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - poetry-core 1.4.0
+    - poetry-core 1.5.1
   run:
     - python
     - {{ pin_compatible('numpy') }} 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,9 @@ requirements:
     - poetry-core 1.5.1
   run:
     - python
-    - {{ pin_compatible('numpy') }} 
+    # numpy pinnings https://github.com/predict-idlab/plotly-resampler/blob/c60833eb4382b3072cb591b36de737dbf769a5ea/pyproject.toml#L43-L45
+    - {{ pin_compatible('numpy') }}  # [py<311]
+    - numpy >=1.24                   # [py>=311]
     - dash >=2.2.0,<3.0.0
     - jupyter-dash >=0.4.2
     - orjson >=3.8.0,<4.0.0


### PR DESCRIPTION
Requirements: https://github.com/predict-idlab/plotly-resampler/blob/v0.8.3.2/pyproject.toml

Actions:
1. Use strong pinning `poetry-core 1.5.1` in `host` (this version has python 3.8-3.11 support but v1.4.0 has missing artifacts on linux-ppc64le for py311)
2. Fix `numpy` in `run` because `numpy 1.24.3 conflicts with any installable versions previously reported` if I create a new dry-run environment locally 