### PR TITLE
Relax pandas constraint to allow using both pandas 1 and 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,20 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 5cac870d6d269cdd71d28def4cae310c609c02aac636c0831176188f16021f44
+  patches:
+    - patches/0001-Relax-pandas-version-constraint.patch
 
 build:
   # s390x missing orjson
   skip: true  # [py<37 or s390x]
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - patch # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - numpy {{ numpy }}
@@ -34,7 +38,7 @@ requirements:
     - dash >=2.2.0,<3.0.0
     - jupyter-dash >=0.4.2
     - orjson >=3.8.0,<4.0.0
-    - pandas >=1.3.5,<2.0.0
+    - pandas >=1
     - plotly >=5.5.0,<6.0.0
     - trace-updater >=0.0.8
     # Optional dependencies:

--- a/recipe/patches/0001-Relax-pandas-version-constraint.patch
+++ b/recipe/patches/0001-Relax-pandas-version-constraint.patch
@@ -1,12 +1,26 @@
-From eb82be861486861535c3422821d94bdf66c9ddd4 Mon Sep 17 00:00:00 2001
+From 239bd986ef1a81b78a2bdf867ba9cd87b3eb895c Mon Sep 17 00:00:00 2001
 From: Jean-Christophe Morin <jcmorin@anaconda.com>
 Date: Wed, 13 Dec 2023 13:34:01 -0500
 Subject: [PATCH] Relax pandas version constraint
 
 ---
- pyproject.toml | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ plotly_resampler/figure_resampler/figure_resampler_interface.py | 2 +-
+ pyproject.toml                                                  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
+diff --git a/plotly_resampler/figure_resampler/figure_resampler_interface.py b/plotly_resampler/figure_resampler/figure_resampler_interface.py
+index 523d569..b5d4c24 100644
+--- a/plotly_resampler/figure_resampler/figure_resampler_interface.py
++++ b/plotly_resampler/figure_resampler/figure_resampler_interface.py
+@@ -511,7 +511,7 @@ class AbstractFigureAggregator(BaseFigure, ABC):
+                 return None
+             elif reference_tz is not None:
+                 if ts.tz is not None:
+-                    assert ts.tz.zone == reference_tz.zone
++                    assert ts.tz.__str__() == reference_tz.__str__()
+                     return ts
+                 else:  # localize -> time remains the same
+                     return ts.tz_localize(reference_tz)
 diff --git a/pyproject.toml b/pyproject.toml
 index 5a4cbdf..5f4dfc1 100644
 --- a/pyproject.toml

--- a/recipe/patches/0001-Relax-pandas-version-constraint.patch
+++ b/recipe/patches/0001-Relax-pandas-version-constraint.patch
@@ -1,0 +1,25 @@
+From eb82be861486861535c3422821d94bdf66c9ddd4 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Wed, 13 Dec 2023 13:34:01 -0500
+Subject: [PATCH] Relax pandas version constraint
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 5a4cbdf..5f4dfc1 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -38,7 +38,7 @@ python = "^3.7.1"
+ jupyter-dash = ">=0.4.2"
+ plotly = "^5.5.0"
+ dash = "^2.2.0"
+-pandas = "^1.3.5"
++pandas = ">=1"
+ trace-updater = ">=0.0.8"
+ numpy = [
+     { version = ">=1.14", python = "<3.11" },
+-- 
+2.43.0
+


### PR DESCRIPTION
plotly-resampler 0.8.3.2

**Destination channel:** defaults

### Links

- [PKG-3416](https://anaconda.atlassian.net/browse/PKG-3416)
- [Upstream repository](https://github.com/predict-idlab/plotly-resampler/tree/v0.8.3.2)
- ~[Upstream changelog/diff]()~

### Explanation of changes:

This PR relaxes the constraint on pandas to allow using both pandas and 2. This is required for autogluon which requires both pandas 2 and plotly-resampler.

After some talks with @ryanskeith, we think this change is safe. We had to apply a small patch to make it work though. The patch is inspired by https://github.com/predict-idlab/plotly-resampler/pull/213/files.

The reasoning behind relaxing the constraint is that we can't update `plotly-resampler` to 0.9.0 (which officially supports both pandas 1 and 2) because it would require to use rust nightly, which we don't allow.

Also, the dependency was relaxed in 0.9.0 (see https://github.com/predict-idlab/plotly-resampler/blob/v0.9.0/pyproject.toml#L40), which suggests we can do it too in 0.8.3.2 and also suggests they simply overly constrained pandas out of caution (and because they use poetry which tries to do everything like in the Javascripr world, which means overly constraining dependencies).

[PKG-3416]: https://anaconda.atlassian.net/browse/PKG-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ